### PR TITLE
feat: OpenFeature compatible Flag Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# FunWithFlags
+
+FunWithFlags is a Go-based feature flag evaluation service that is being built to comply with the [OpenFeature](https://openfeature.dev/) specification. The service exposes a lightweight HTTP API that OpenFeature clients can call today, with roadmap work planned for PostgreSQL-backed persistence and an administrative UI.
+
+## Project Status
+- `POST /api/v1/flags/{key}/evaluate` returns typed variation data along with OpenFeature-compatible reasons.
+- `/healthz` and `/readyz` endpoints provide basic liveness and readiness probes.
+- Flags are stored in an in-memory repository while the PostgreSQL implementation is designed.
+- End-to-end coverage includes an OpenFeature Go SDK test that drives the HTTP endpoint.
+
+## Prerequisites
+- Go 1.24 or newer (see `go.mod` for the authoritative version).
+
+## Run the Server
+```bash
+make run
+# or
+go run ./cmd/server
+```
+The server listens on `:8080` by default.
+
+## Evaluating a Flag
+Send a JSON payload containing the evaluation context:
+```bash
+curl -X POST http://localhost:8080/api/v1/flags/checkout-flow/evaluate \
+  -H 'Content-Type: application/json' \
+  -d '{"context": {"country": "DE", "userId": "1234"}}'
+```
+Sample response (assuming the `checkout-flow` flag exists and is enabled):
+```json
+{
+  "flagKey": "checkout-flow",
+  "variationKey": "enabled",
+  "variationType": "boolean",
+  "value": true,
+  "reason": "TARGET_MATCH"
+}
+```
+Admin endpoints are not available yet, so flags must currently be seeded programmatically (e.g., within tests or temporary setup code).
+
+## Development Workflow
+- `make fmt` — format the code.
+- `make lint` — run `go vet`.
+- `make test` — execute the unit and integration tests, including the OpenFeature HTTP client exercise.
+- `make build` — build the server binary into `bin/funwithflags`.
+
+## Repository Layout
+- `cmd/server` — application entry point and process wiring.
+- `internal/app` — lifecycle management for the HTTP server.
+- `internal/httpserver` — HTTP router, handlers, and response helpers.
+- `internal/flag` — domain model, in-memory repository, evaluation engine, and tests.
+- `docs/feature-flag-service-plan.md` — iterative development plan and roadmap.
+
+## Next Steps
+- Add PostgreSQL persistence with migrations and data access abstractions.
+- Expose flag management APIs that the upcoming UI can consume.
+- Expand test coverage for error paths and additional OpenFeature scenarios.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,12 @@
 module github.com/deicon/funwithflags
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.24.5
+
+require github.com/open-feature/go-sdk v1.16.0
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	go.uber.org/mock v0.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/open-feature/go-sdk v1.16.0 h1:5NCHYv5slvNBIZhYXAzAufo0OI59OACZ5tczVqSE+Tg=
+github.com/open-feature/go-sdk v1.16.0/go.mod h1:EIF40QcoYT1VbQkMPy2ZJH4kvZeY+qGUXAorzSWgKSo=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
+golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
+golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/deicon/funwithflags/internal/flag"
 	"github.com/deicon/funwithflags/internal/httpserver"
 )
 
@@ -15,12 +16,24 @@ type App struct {
 }
 
 func New() (*App, error) {
-	handler := httpserver.NewRouter()
+	repo := flag.NewInMemoryRepository()
+	engine := flag.NewEngine()
+	flagService, err := flag.NewService(repo, engine)
+	if err != nil {
+		return nil, fmt.Errorf("init flag service: %w", err)
+	}
+
+	router, err := httpserver.NewRouter(httpserver.Config{
+		FlagService: flagService,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init router: %w", err)
+	}
 
 	return &App{
 		server: &http.Server{
 			Addr:              ":8080",
-			Handler:           handler,
+			Handler:           router,
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 	}, nil

--- a/internal/flag/errors.go
+++ b/internal/flag/errors.go
@@ -1,0 +1,9 @@
+package flag
+
+import "errors"
+
+var (
+	ErrFlagNotFound = errors.New("flag not found")
+	ErrFlagConflict = errors.New("flag update conflict")
+	ErrInvalidFlag  = errors.New("invalid feature flag")
+)

--- a/internal/flag/evaluator.go
+++ b/internal/flag/evaluator.go
@@ -1,0 +1,276 @@
+package flag
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"reflect"
+	"strings"
+)
+
+type Engine struct{}
+
+func NewEngine() *Engine {
+	return &Engine{}
+}
+
+func (e *Engine) Evaluate(ctx context.Context, flag FeatureFlag, attrs EvaluationContext) (EvaluationResult, error) {
+	variationMap := buildVariationMap(flag.Variations)
+	if !flag.Enabled {
+		return buildResultFromKey(flag.DefaultKey, variationMap, ReasonDisabled)
+	}
+
+	for _, rule := range flag.Rules {
+		result, matched, err := evaluateRule(rule, attrs, variationMap)
+		if err != nil {
+			return EvaluationResult{}, err
+		}
+		if matched {
+			return result, nil
+		}
+	}
+
+	return buildResultFromKey(flag.DefaultKey, variationMap, ReasonDefault)
+}
+
+func evaluateRule(rule Rule, attrs EvaluationContext, variations map[string]Variation) (EvaluationResult, bool, error) {
+	matched, err := conditionsMatch(rule.Conditions, attrs)
+	if err != nil || !matched {
+		return EvaluationResult{}, matched, err
+	}
+
+	if rule.Rollout != nil {
+		return evaluateRollout(rule.Rollout, attrs, variations)
+	}
+
+	result, err := buildResultFromKey(rule.VariationKey, variations, ReasonTargetMatch)
+	if err != nil {
+		return EvaluationResult{}, false, err
+	}
+	return result, true, nil
+}
+
+func buildVariationMap(variations []Variation) map[string]Variation {
+	m := make(map[string]Variation, len(variations))
+	for _, variation := range variations {
+		m[variation.Key] = variation
+	}
+	return m
+}
+
+func buildResultFromKey(key string, variations map[string]Variation, reason string) (EvaluationResult, error) {
+	variation, ok := variations[key]
+	if !ok {
+		return EvaluationResult{}, fmt.Errorf("variation %q not defined", key)
+	}
+	return EvaluationResult{Variation: variation, Reason: reason}, nil
+}
+
+func conditionsMatch(conditions []Condition, attrs EvaluationContext) (bool, error) {
+	for _, condition := range conditions {
+		value, exists := attrs[condition.Attribute]
+		switch condition.Operator {
+		case MatcherExists:
+			if !exists {
+				return false, nil
+			}
+		case MatcherEquals:
+			if !exists || !equals(value, condition.Value) {
+				return false, nil
+			}
+		case MatcherNotEquals:
+			if !exists || equals(value, condition.Value) {
+				return false, nil
+			}
+		case MatcherContains:
+			if !exists || !contains(value, condition.Value) {
+				return false, nil
+			}
+		case MatcherStartsWith:
+			if !exists || !startsWith(value, condition.Value) {
+				return false, nil
+			}
+		case MatcherEndsWith:
+			if !exists || !endsWith(value, condition.Value) {
+				return false, nil
+			}
+		case MatcherGreater:
+			if !exists || !compareNumeric(value, condition.Value, func(a, b float64) bool { return a > b }) {
+				return false, nil
+			}
+		case MatcherLess:
+			if !exists || !compareNumeric(value, condition.Value, func(a, b float64) bool { return a < b }) {
+				return false, nil
+			}
+		case MatcherIn:
+			if !exists || !inCollection(value, condition.Value) {
+				return false, nil
+			}
+		default:
+			return false, fmt.Errorf("unsupported operator %q", condition.Operator)
+		}
+	}
+	return true, nil
+}
+
+func equals(lhs, rhs any) bool {
+	return reflect.DeepEqual(normalize(lhs), normalize(rhs))
+}
+
+func normalize(value any) any {
+	switch v := value.(type) {
+	case int:
+		return float64(v)
+	case int8:
+		return float64(v)
+	case int16:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case uint:
+		return float64(v)
+	case uint8:
+		return float64(v)
+	case uint16:
+		return float64(v)
+	case uint32:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	case float32:
+		return float64(v)
+	default:
+		return v
+	}
+}
+
+func contains(attr, value any) bool {
+	attrStr, ok := attr.(string)
+	if !ok {
+		return false
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return false
+	}
+
+	return strings.Contains(attrStr, valueStr)
+}
+
+func startsWith(attr, value any) bool {
+	attrStr, ok := attr.(string)
+	if !ok {
+		return false
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(attrStr, valueStr)
+}
+
+func endsWith(attr, value any) bool {
+	attrStr, ok := attr.(string)
+	if !ok {
+		return false
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return false
+	}
+	return strings.HasSuffix(attrStr, valueStr)
+}
+
+func compareNumeric(lhs, rhs any, comparator func(a, b float64) bool) bool {
+	left, ok := toFloat64(lhs)
+	if !ok {
+		return false
+	}
+	right, ok := toFloat64(rhs)
+	if !ok {
+		return false
+	}
+	return comparator(left, right)
+}
+
+func toFloat64(value any) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func inCollection(value any, collection any) bool {
+	col := reflect.ValueOf(collection)
+	if !col.IsValid() {
+		return false
+	}
+	if col.Kind() != reflect.Slice && col.Kind() != reflect.Array {
+		return false
+	}
+	for i := 0; i < col.Len(); i++ {
+		if equals(value, col.Index(i).Interface()) {
+			return true
+		}
+	}
+	return false
+}
+
+func evaluateRollout(rollout *PercentageRollout, attrs EvaluationContext, variations map[string]Variation) (EvaluationResult, bool, error) {
+	value, ok := attrs[rollout.Attribute]
+	if !ok {
+		return EvaluationResult{}, false, nil
+	}
+
+	hashInput := fmt.Sprintf("%s:%v", rollout.Seed, value)
+	hasher := fnv.New32a()
+	if _, err := hasher.Write([]byte(hashInput)); err != nil {
+		return EvaluationResult{}, false, fmt.Errorf("hash rollout seed: %w", err)
+	}
+
+	point := float64(hasher.Sum32()%10000) / 100.0
+	var cumulative float64
+	for _, bucket := range rollout.Buckets {
+		cumulative += bucket.Weight
+		if point < cumulative {
+			result, err := buildResultFromKey(bucket.VariationKey, variations, ReasonPercentageRollout)
+			if err != nil {
+				return EvaluationResult{}, false, err
+			}
+			return result, true, nil
+		}
+	}
+
+	last := rollout.Buckets[len(rollout.Buckets)-1]
+	result, err := buildResultFromKey(last.VariationKey, variations, ReasonPercentageRollout)
+	if err != nil {
+		return EvaluationResult{}, false, err
+	}
+	return result, true, nil
+}

--- a/internal/flag/evaluator_test.go
+++ b/internal/flag/evaluator_test.go
@@ -1,0 +1,186 @@
+package flag
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"testing"
+)
+
+func TestEngine_ReturnsDefaultWhenDisabled(t *testing.T) {
+	engine := NewEngine()
+	flag := FeatureFlag{
+		Key:        "checkout",
+		Enabled:    false,
+		DefaultKey: "control",
+		Variations: []Variation{
+			{Key: "control", Type: BooleanVariation, Value: false},
+			{Key: "variant", Type: BooleanVariation, Value: true},
+		},
+	}
+
+	result, err := engine.Evaluate(context.Background(), flag, EvaluationContext{"country": "DE"})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+
+	if result.Variation.Key != "control" {
+		t.Fatalf("expected default variation, got %s", result.Variation.Key)
+	}
+	if result.Reason != ReasonDisabled {
+		t.Fatalf("expected reason %s, got %s", ReasonDisabled, result.Reason)
+	}
+}
+
+func TestEngine_StaticRuleMatch(t *testing.T) {
+	engine := NewEngine()
+	flag := FeatureFlag{
+		Key:        "search-layout",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []Variation{
+			{Key: "control", Type: StringVariation, Value: "legacy"},
+			{Key: "experiment", Type: StringVariation, Value: "modern"},
+		},
+		Rules: []Rule{
+			{
+				ID:           "vip-eu",
+				VariationKey: "experiment",
+				Conditions: []Condition{
+					{Attribute: "country", Operator: MatcherEquals, Value: "DE"},
+					{Attribute: "plan", Operator: MatcherExists},
+					{Attribute: "tenure", Operator: MatcherGreater, Value: 12},
+					{Attribute: "segment", Operator: MatcherIn, Value: []string{"beta", "vip"}},
+				},
+			},
+		},
+	}
+
+	attrs := EvaluationContext{
+		"country": "DE",
+		"plan":    "pro",
+		"tenure":  18,
+		"segment": "vip",
+	}
+
+	result, err := engine.Evaluate(context.Background(), flag, attrs)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+
+	if result.Variation.Key != "experiment" {
+		t.Fatalf("expected experiment variation, got %s", result.Variation.Key)
+	}
+	if result.Reason != ReasonTargetMatch {
+		t.Fatalf("expected reason %s, got %s", ReasonTargetMatch, result.Reason)
+	}
+}
+
+func TestEngine_ReturnsDefaultWhenNoRuleMatches(t *testing.T) {
+	engine := NewEngine()
+	flag := FeatureFlag{
+		Key:        "search-layout",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []Variation{
+			{Key: "control", Type: StringVariation, Value: "legacy"},
+			{Key: "experiment", Type: StringVariation, Value: "modern"},
+		},
+		Rules: []Rule{
+			{
+				ID:           "vip-eu",
+				VariationKey: "experiment",
+				Conditions: []Condition{
+					{Attribute: "country", Operator: MatcherEquals, Value: "DE"},
+				},
+			},
+		},
+	}
+
+	attrs := EvaluationContext{
+		"country": "US",
+	}
+
+	result, err := engine.Evaluate(context.Background(), flag, attrs)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+
+	if result.Variation.Key != "control" {
+		t.Fatalf("expected default variation, got %s", result.Variation.Key)
+	}
+	if result.Reason != ReasonDefault {
+		t.Fatalf("expected reason %s, got %s", ReasonDefault, result.Reason)
+	}
+}
+
+func TestEngine_PercentageRolloutDeterministic(t *testing.T) {
+	engine := NewEngine()
+	flag := FeatureFlag{
+		Key:        "feed-algorithm",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []Variation{
+			{Key: "control", Type: StringVariation, Value: "classic"},
+			{Key: "ml", Type: StringVariation, Value: "personalized"},
+		},
+		Rules: []Rule{
+			{
+				ID: "emea-rollout",
+				Conditions: []Condition{
+					{Attribute: "region", Operator: MatcherEquals, Value: "EMEA"},
+				},
+				Rollout: &PercentageRollout{
+					Attribute: "user_id",
+					Seed:      "feed-algorithm",
+					Buckets: []RolloutBucket{
+						{VariationKey: "control", Weight: 40},
+						{VariationKey: "ml", Weight: 60},
+					},
+				},
+			},
+		},
+	}
+
+	attrs := EvaluationContext{
+		"region":  "EMEA",
+		"user_id": "user-123",
+	}
+
+	expected := expectedRolloutVariation(flag.Rules[0].Rollout, attrs["user_id"])
+
+	first, err := engine.Evaluate(context.Background(), flag, attrs)
+	if err != nil {
+		t.Fatalf("Evaluate first: %v", err)
+	}
+	second, err := engine.Evaluate(context.Background(), flag, attrs)
+	if err != nil {
+		t.Fatalf("Evaluate second: %v", err)
+	}
+
+	if first.Variation.Key != expected {
+		t.Fatalf("expected variation %s from rollout, got %s", expected, first.Variation.Key)
+	}
+	if first.Reason != ReasonPercentageRollout {
+		t.Fatalf("expected reason %s, got %s", ReasonPercentageRollout, first.Reason)
+	}
+	if second.Variation.Key != first.Variation.Key {
+		t.Fatalf("expected deterministic rollout, got %s and %s", first.Variation.Key, second.Variation.Key)
+	}
+}
+
+func expectedRolloutVariation(rollout *PercentageRollout, attrValue any) string {
+	hashInput := fmt.Sprintf("%s:%v", rollout.Seed, attrValue)
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(hashInput))
+
+	point := float64(hasher.Sum32()%10000) / 100.0
+	var cumulative float64
+	for _, bucket := range rollout.Buckets {
+		cumulative += bucket.Weight
+		if point < cumulative {
+			return bucket.VariationKey
+		}
+	}
+	return rollout.Buckets[len(rollout.Buckets)-1].VariationKey
+}

--- a/internal/flag/memory_repository.go
+++ b/internal/flag/memory_repository.go
@@ -1,0 +1,305 @@
+package flag
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"sync"
+	"time"
+)
+
+type InMemoryRepository struct {
+	mu    sync.RWMutex
+	flags map[string]FeatureFlag
+	now   func() time.Time
+}
+
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		flags: make(map[string]FeatureFlag),
+		now:   func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (r *InMemoryRepository) GetFlag(ctx context.Context, key string) (FeatureFlag, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	flag, ok := r.flags[key]
+	if !ok {
+		return FeatureFlag{}, ErrFlagNotFound
+	}
+
+	return cloneFlag(flag), nil
+}
+
+func (r *InMemoryRepository) ListFlags(ctx context.Context) ([]FeatureFlag, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	flags := make([]FeatureFlag, 0, len(r.flags))
+	for _, f := range r.flags {
+		flags = append(flags, cloneFlag(f))
+	}
+
+	return flags, nil
+}
+
+func (r *InMemoryRepository) UpsertFlag(ctx context.Context, flag FeatureFlag) error {
+	if err := validateFlag(flag); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidFlag, err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := r.now()
+	existing, exists := r.flags[flag.Key]
+	if !exists {
+		flag.CreatedAt = now
+		flag.UpdatedAt = now
+		r.flags[flag.Key] = cloneFlag(flag)
+		return nil
+	}
+
+	if !flag.UpdatedAt.Equal(existing.UpdatedAt) {
+		return ErrFlagConflict
+	}
+
+	flag.CreatedAt = existing.CreatedAt
+	flag.UpdatedAt = now
+	r.flags[flag.Key] = cloneFlag(flag)
+
+	return nil
+}
+
+func (r *InMemoryRepository) DeleteFlag(ctx context.Context, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.flags[key]; !exists {
+		return ErrFlagNotFound
+	}
+
+	delete(r.flags, key)
+	return nil
+}
+
+func cloneFlag(flag FeatureFlag) FeatureFlag {
+	cpy := flag
+	if len(flag.Variations) > 0 {
+		cpy.Variations = make([]Variation, len(flag.Variations))
+		copy(cpy.Variations, flag.Variations)
+	}
+	if len(flag.Rules) > 0 {
+		cpy.Rules = make([]Rule, len(flag.Rules))
+		for i, rule := range flag.Rules {
+			cpy.Rules[i] = cloneRule(rule)
+		}
+	}
+	return cpy
+}
+
+func validateFlag(flag FeatureFlag) error {
+	if flag.Key == "" {
+		return fmt.Errorf("key is required")
+	}
+	if len(flag.Variations) == 0 {
+		return fmt.Errorf("at least one variation required")
+	}
+
+	keys := make(map[string]struct{}, len(flag.Variations))
+	var defaultFound bool
+	for _, variation := range flag.Variations {
+		if variation.Key == "" {
+			return fmt.Errorf("variation key is required")
+		}
+		if _, exists := keys[variation.Key]; exists {
+			return fmt.Errorf("duplicate variation key %q", variation.Key)
+		}
+		keys[variation.Key] = struct{}{}
+
+		if err := validateVariation(variation); err != nil {
+			return err
+		}
+		if variation.Key == flag.DefaultKey {
+			defaultFound = true
+		}
+	}
+
+	if flag.DefaultKey == "" {
+		return fmt.Errorf("default variation key is required")
+	}
+
+	if !defaultFound {
+		return fmt.Errorf("default variation %q not found", flag.DefaultKey)
+	}
+
+	for _, rule := range flag.Rules {
+		if err := validateRule(rule, keys); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateVariation(variation Variation) error {
+	switch variation.Type {
+	case BooleanVariation:
+		if _, ok := variation.Value.(bool); !ok {
+			return fmt.Errorf("variation %q expects boolean value", variation.Key)
+		}
+	case StringVariation:
+		if _, ok := variation.Value.(string); !ok {
+			return fmt.Errorf("variation %q expects string value", variation.Key)
+		}
+	case NumberVariation:
+		if !isNumeric(variation.Value) {
+			return fmt.Errorf("variation %q expects numeric value", variation.Key)
+		}
+	case ObjectVariation:
+		if !isObjectType(variation.Value) {
+			return fmt.Errorf("variation %q expects object value", variation.Key)
+		}
+	default:
+		return fmt.Errorf("variation %q has unsupported type %q", variation.Key, variation.Type)
+	}
+	return nil
+}
+
+func isNumeric(value any) bool {
+	switch value.(type) {
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func isObjectType(value any) bool {
+	if value == nil {
+		return false
+	}
+	if _, ok := value.([]byte); ok {
+		return true
+	}
+
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Map, reflect.Struct:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneRule(rule Rule) Rule {
+	cpy := rule
+	if len(rule.Conditions) > 0 {
+		cpy.Conditions = make([]Condition, len(rule.Conditions))
+		copy(cpy.Conditions, rule.Conditions)
+	}
+	if rule.Rollout != nil {
+		rolloutCopy := *rule.Rollout
+		if len(rule.Rollout.Buckets) > 0 {
+			rolloutCopy.Buckets = make([]RolloutBucket, len(rule.Rollout.Buckets))
+			copy(rolloutCopy.Buckets, rule.Rollout.Buckets)
+		}
+		cpy.Rollout = &rolloutCopy
+	}
+	return cpy
+}
+
+func validateRule(rule Rule, variations map[string]struct{}) error {
+	for _, condition := range rule.Conditions {
+		if condition.Attribute == "" {
+			return fmt.Errorf("rule %q condition missing attribute", rule.ID)
+		}
+		if err := validateCondition(condition); err != nil {
+			return fmt.Errorf("rule %q: %w", rule.ID, err)
+		}
+	}
+
+	if rule.Rollout != nil {
+		if rule.VariationKey != "" {
+			return fmt.Errorf("rule %q cannot define both variation key and rollout", rule.ID)
+		}
+		if err := validateRollout(rule.Rollout, variations); err != nil {
+			return fmt.Errorf("rule %q rollout: %w", rule.ID, err)
+		}
+		return nil
+	}
+
+	if rule.VariationKey == "" {
+		return fmt.Errorf("rule %q must specify variation key when rollout absent", rule.ID)
+	}
+
+	if _, ok := variations[rule.VariationKey]; !ok {
+		return fmt.Errorf("rule %q references unknown variation %q", rule.ID, rule.VariationKey)
+	}
+
+	return nil
+}
+
+func validateCondition(condition Condition) error {
+	switch condition.Operator {
+	case MatcherExists:
+		return nil
+	case MatcherEquals, MatcherNotEquals:
+		if condition.Value == nil {
+			return fmt.Errorf("operator %q requires value", condition.Operator)
+		}
+		return nil
+	case MatcherContains, MatcherStartsWith, MatcherEndsWith:
+		if _, ok := condition.Value.(string); !ok {
+			return fmt.Errorf("operator %q expects string value", condition.Operator)
+		}
+		return nil
+	case MatcherGreater, MatcherLess:
+		if !isNumeric(condition.Value) {
+			return fmt.Errorf("operator %q expects numeric value", condition.Operator)
+		}
+		return nil
+	case MatcherIn:
+		rv := reflect.ValueOf(condition.Value)
+		if !rv.IsValid() || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
+			return fmt.Errorf("operator %q expects slice or array value", condition.Operator)
+		}
+		if rv.Len() == 0 {
+			return fmt.Errorf("operator %q expects non-empty collection", condition.Operator)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown operator %q", condition.Operator)
+	}
+}
+
+func validateRollout(rollout *PercentageRollout, variations map[string]struct{}) error {
+	if rollout.Attribute == "" {
+		return fmt.Errorf("attribute is required")
+	}
+	if len(rollout.Buckets) == 0 {
+		return fmt.Errorf("at least one rollout bucket required")
+	}
+
+	var total float64
+	for _, bucket := range rollout.Buckets {
+		if bucket.Weight <= 0 {
+			return fmt.Errorf("bucket for variation %q must have positive weight", bucket.VariationKey)
+		}
+		if _, ok := variations[bucket.VariationKey]; !ok {
+			return fmt.Errorf("bucket references unknown variation %q", bucket.VariationKey)
+		}
+		total += bucket.Weight
+	}
+
+	if math.Abs(total-100.0) > 0.0001 {
+		return fmt.Errorf("rollout weights must total 100, got %f", total)
+	}
+
+	return nil
+}

--- a/internal/flag/memory_repository_test.go
+++ b/internal/flag/memory_repository_test.go
@@ -1,0 +1,161 @@
+package flag
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInMemoryRepository_UpsertAndGet(t *testing.T) {
+	repo := NewInMemoryRepository()
+	now := time.Date(2024, 10, 1, 12, 0, 0, 0, time.UTC)
+	repo.now = func() time.Time { return now }
+
+	flag := FeatureFlag{
+		Key:        "checkout-experience",
+		Name:       "Checkout Experience",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []Variation{
+			{Key: "control", Type: BooleanVariation, Value: false},
+			{Key: "variant", Type: BooleanVariation, Value: true},
+		},
+	}
+
+	if err := repo.UpsertFlag(context.Background(), flag); err != nil {
+		t.Fatalf("UpsertFlag: %v", err)
+	}
+
+	stored, err := repo.GetFlag(context.Background(), flag.Key)
+	if err != nil {
+		t.Fatalf("GetFlag: %v", err)
+	}
+
+	if stored.CreatedAt != now || stored.UpdatedAt != now {
+		t.Fatalf("expected timestamps to be set to %v, got created=%v updated=%v", now, stored.CreatedAt, stored.UpdatedAt)
+	}
+
+	if !stored.Enabled {
+		t.Fatalf("expected stored flag to remain enabled")
+	}
+
+	stored.Variations[0].Value = true
+
+	original, err := repo.GetFlag(context.Background(), flag.Key)
+	if err != nil {
+		t.Fatalf("GetFlag: %v", err)
+	}
+
+	if original.Variations[0].Value.(bool) != false {
+		t.Fatalf("expected stored variation to be unaffected by caller mutation")
+	}
+}
+
+func TestInMemoryRepository_UpdateWithOptimisticLock(t *testing.T) {
+	repo := NewInMemoryRepository()
+	first := time.Date(2024, 10, 1, 12, 0, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	repo.now = func() time.Time { return first }
+	flag := FeatureFlag{
+		Key:        "search-layout",
+		DefaultKey: "old",
+		Variations: []Variation{
+			{Key: "old", Type: StringVariation, Value: "classic"},
+			{Key: "new", Type: StringVariation, Value: "modern"},
+		},
+	}
+	if err := repo.UpsertFlag(context.Background(), flag); err != nil {
+		t.Fatalf("UpsertFlag initial: %v", err)
+	}
+
+	current, err := repo.GetFlag(context.Background(), flag.Key)
+	if err != nil {
+		t.Fatalf("GetFlag: %v", err)
+	}
+
+	repo.now = func() time.Time { return second }
+	current.DefaultKey = "new"
+	if err := repo.UpsertFlag(context.Background(), current); err != nil {
+		t.Fatalf("UpsertFlag update: %v", err)
+	}
+
+	updated, err := repo.GetFlag(context.Background(), flag.Key)
+	if err != nil {
+		t.Fatalf("GetFlag: %v", err)
+	}
+
+	if updated.DefaultKey != "new" {
+		t.Fatalf("expected default key to update, got %q", updated.DefaultKey)
+	}
+	if updated.CreatedAt != first {
+		t.Fatalf("expected created at to remain unchanged, got %v", updated.CreatedAt)
+	}
+	if updated.UpdatedAt != second {
+		t.Fatalf("expected updated at to change to %v, got %v", second, updated.UpdatedAt)
+	}
+}
+
+func TestInMemoryRepository_UpdateConflict(t *testing.T) {
+	repo := NewInMemoryRepository()
+
+	flag := FeatureFlag{
+		Key:        "recommendations",
+		DefaultKey: "off",
+		Variations: []Variation{
+			{Key: "off", Type: BooleanVariation, Value: false},
+			{Key: "on", Type: BooleanVariation, Value: true},
+		},
+	}
+
+	if err := repo.UpsertFlag(context.Background(), flag); err != nil {
+		t.Fatalf("UpsertFlag initial: %v", err)
+	}
+
+	stale := flag
+	stale.UpdatedAt = time.Time{}
+
+	if err := repo.UpsertFlag(context.Background(), stale); !errors.Is(err, ErrFlagConflict) {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestInMemoryRepository_Delete(t *testing.T) {
+	repo := NewInMemoryRepository()
+	flag := FeatureFlag{
+		Key:        "recommendations",
+		DefaultKey: "off",
+		Variations: []Variation{
+			{Key: "off", Type: BooleanVariation, Value: false},
+			{Key: "on", Type: BooleanVariation, Value: true},
+		},
+	}
+	if err := repo.UpsertFlag(context.Background(), flag); err != nil {
+		t.Fatalf("UpsertFlag initial: %v", err)
+	}
+
+	if err := repo.DeleteFlag(context.Background(), flag.Key); err != nil {
+		t.Fatalf("DeleteFlag: %v", err)
+	}
+
+	if _, err := repo.GetFlag(context.Background(), flag.Key); !errors.Is(err, ErrFlagNotFound) {
+		t.Fatalf("expected not found after delete, got %v", err)
+	}
+}
+
+func TestInMemoryRepository_InvalidFlag(t *testing.T) {
+	repo := NewInMemoryRepository()
+
+	flag := FeatureFlag{
+		Key:        "badflag",
+		DefaultKey: "missing",
+		Variations: []Variation{
+			{Key: "control", Type: BooleanVariation, Value: true},
+		},
+	}
+
+	if err := repo.UpsertFlag(context.Background(), flag); !errors.Is(err, ErrInvalidFlag) {
+		t.Fatalf("expected invalid flag error, got %v", err)
+	}
+}

--- a/internal/flag/model.go
+++ b/internal/flag/model.go
@@ -28,7 +28,7 @@ type FeatureFlag struct {
 	Enabled     bool
 	DefaultKey  string
 	Variations  []Variation
-	Rules       []TargetingRule
+	Rules       []Rule
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
@@ -40,6 +40,52 @@ type EvaluationResult struct {
 	Reason    string
 }
 
+const (
+	ReasonTargetMatch       = "TARGET_MATCH"
+	ReasonPercentageRollout = "PERCENTAGE_ROLLOUT"
+	ReasonDefault           = "DEFAULT"
+	ReasonDisabled          = "DISABLED"
+)
+
+type MatcherOperator string
+
+const (
+	MatcherEquals     MatcherOperator = "equals"
+	MatcherNotEquals  MatcherOperator = "not_equals"
+	MatcherContains   MatcherOperator = "contains"
+	MatcherStartsWith MatcherOperator = "starts_with"
+	MatcherEndsWith   MatcherOperator = "ends_with"
+	MatcherGreater    MatcherOperator = "greater_than"
+	MatcherLess       MatcherOperator = "less_than"
+	MatcherIn         MatcherOperator = "in"
+	MatcherExists     MatcherOperator = "exists"
+)
+
+type Condition struct {
+	Attribute string
+	Operator  MatcherOperator
+	Value     any
+}
+
+type RolloutBucket struct {
+	VariationKey string
+	Weight       float64
+}
+
+type PercentageRollout struct {
+	Attribute string
+	Seed      string
+	Buckets   []RolloutBucket
+}
+
+type Rule struct {
+	ID           string
+	Description  string
+	Conditions   []Condition
+	VariationKey string
+	Rollout      *PercentageRollout
+}
+
 type Repository interface {
 	GetFlag(ctx context.Context, key string) (FeatureFlag, error)
 	ListFlags(ctx context.Context) ([]FeatureFlag, error)
@@ -49,8 +95,4 @@ type Repository interface {
 
 type Evaluator interface {
 	Evaluate(ctx context.Context, flag FeatureFlag, attrs EvaluationContext) (EvaluationResult, error)
-}
-
-type TargetingRule interface {
-	Evaluate(ctx context.Context, attrs EvaluationContext) (EvaluationResult, bool, error)
 }

--- a/internal/flag/openfeature_http_integration_test.go
+++ b/internal/flag/openfeature_http_integration_test.go
@@ -1,0 +1,388 @@
+package flag_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	flagpkg "github.com/deicon/funwithflags/internal/flag"
+	"github.com/deicon/funwithflags/internal/httpserver"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+type httpProvider struct {
+	baseURL  string
+	client   *http.Client
+	metadata openfeature.Metadata
+}
+
+type apiEvaluateRequest struct {
+	Context map[string]any `json:"context,omitempty"`
+}
+
+type apiEvaluateResponse struct {
+	FlagKey       string `json:"flagKey"`
+	VariationKey  string `json:"variationKey"`
+	VariationType string `json:"variationType"`
+	Value         any    `json:"value"`
+	Reason        string `json:"reason"`
+}
+
+type apiErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func newHTTPProvider(baseURL string) *httpProvider {
+	return &httpProvider{
+		baseURL:  baseURL,
+		metadata: openfeature.Metadata{Name: "funwithflags-http"},
+	}
+}
+
+func (p *httpProvider) Metadata() openfeature.Metadata {
+	return p.metadata
+}
+
+func (p *httpProvider) Hooks() []openfeature.Hook {
+	return nil
+}
+
+func (p *httpProvider) Init(openfeature.EvaluationContext) error {
+	if p.client == nil {
+		p.client = &http.Client{Timeout: 2 * time.Second}
+	}
+	return nil
+}
+
+func (p *httpProvider) Shutdown() {
+	if p.client != nil {
+		p.client.CloseIdleConnections()
+	}
+}
+
+func (p *httpProvider) BooleanEvaluation(ctx context.Context, flagKey string, defaultValue bool, flatCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+	resp, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.BoolResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := resp.Value.(bool)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not boolean")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.BoolResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.BoolResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *httpProvider) StringEvaluation(ctx context.Context, flagKey string, defaultValue string, flatCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+	resp, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.StringResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := resp.Value.(string)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not string")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.StringResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.StringResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *httpProvider) FloatEvaluation(ctx context.Context, flagKey string, defaultValue float64, flatCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+	resp, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.FloatResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := coerceFloat64(resp.Value)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not float")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.FloatResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.FloatResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *httpProvider) IntEvaluation(ctx context.Context, flagKey string, defaultValue int64, flatCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+	resp, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.IntResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := coerceInt64(resp.Value)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not int")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.IntResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.IntResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *httpProvider) ObjectEvaluation(ctx context.Context, flagKey string, defaultValue any, flatCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	resp, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.InterfaceResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.InterfaceResolutionDetail{Value: resp.Value, ProviderResolutionDetail: detail}
+}
+
+func (p *httpProvider) evaluate(ctx context.Context, flagKey string, flatCtx openfeature.FlattenedContext) (apiEvaluateResponse, openfeature.ProviderResolutionDetail, error) {
+	if p.client == nil {
+		err := errors.New("http client not initialized")
+		return apiEvaluateResponse{}, openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+		}, err
+	}
+
+	attrs := make(map[string]any, len(flatCtx))
+	for k, v := range flatCtx {
+		attrs[k] = v
+	}
+
+	payload, err := json.Marshal(apiEvaluateRequest{Context: attrs})
+	if err != nil {
+		detail := openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewGeneralResolutionError(fmt.Sprintf("encode request: %v", err)),
+		}
+		return apiEvaluateResponse{}, detail, err
+	}
+
+	base := strings.TrimSuffix(p.baseURL, "/")
+	endpoint := fmt.Sprintf("%s/api/v1/flags/%s/evaluate", base, url.PathEscape(flagKey))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		detail := openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewGeneralResolutionError(fmt.Sprintf("create request: %v", err)),
+		}
+		return apiEvaluateResponse{}, detail, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		detail := openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewGeneralResolutionError(fmt.Sprintf("http request: %v", err)),
+		}
+		return apiEvaluateResponse{}, detail, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		var apiErr apiErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
+			apiErr.Error = "flag not found"
+		}
+		msg := apiErr.Error
+		if msg == "" {
+			msg = "flag not found"
+		}
+		detail := openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewFlagNotFoundResolutionError(msg),
+		}
+		return apiEvaluateResponse{}, detail, errors.New(msg)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("unexpected status %d", resp.StatusCode)
+		} else {
+			msg = fmt.Sprintf("status %d: %s", resp.StatusCode, msg)
+		}
+		detail := openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewGeneralResolutionError(msg),
+		}
+		return apiEvaluateResponse{}, detail, errors.New(msg)
+	}
+
+	var apiResp apiEvaluateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		detail := openfeature.ProviderResolutionDetail{
+			Reason:          openfeature.ErrorReason,
+			ResolutionError: openfeature.NewGeneralResolutionError(fmt.Sprintf("decode response: %v", err)),
+		}
+		return apiEvaluateResponse{}, detail, err
+	}
+
+	detail := openfeature.ProviderResolutionDetail{
+		Reason:  mapReason(apiResp.Reason),
+		Variant: apiResp.VariationKey,
+	}
+
+	return apiResp, detail, nil
+}
+
+func mapReason(reason string) openfeature.Reason {
+	switch reason {
+	case flagpkg.ReasonTargetMatch:
+		return openfeature.TargetingMatchReason
+	case flagpkg.ReasonPercentageRollout:
+		return openfeature.SplitReason
+	case flagpkg.ReasonDisabled:
+		return openfeature.DisabledReason
+	case flagpkg.ReasonDefault:
+		return openfeature.DefaultReason
+	default:
+		return openfeature.UnknownReason
+	}
+}
+
+func coerceFloat64(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func coerceInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int8:
+		return int64(v), true
+	case int16:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint:
+		return int64(v), true
+	case uint8:
+		return int64(v), true
+	case uint16:
+		return int64(v), true
+	case uint32:
+		return int64(v), true
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(v), true
+	case float32:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func TestOpenFeatureClientHTTPIntegration(t *testing.T) {
+	openfeature.Shutdown()
+
+	repo := flagpkg.NewInMemoryRepository()
+	engine := flagpkg.NewEngine()
+	service, err := flagpkg.NewService(repo, engine)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	flagDef := flagpkg.FeatureFlag{
+		Key:        "checkout-flow",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []flagpkg.Variation{
+			{Key: "control", Type: flagpkg.BooleanVariation, Value: false},
+			{Key: "enabled", Type: flagpkg.BooleanVariation, Value: true},
+		},
+		Rules: []flagpkg.Rule{
+			{
+				ID:           "country-de",
+				VariationKey: "enabled",
+				Conditions: []flagpkg.Condition{
+					{Attribute: "country", Operator: flagpkg.MatcherEquals, Value: "DE"},
+				},
+			},
+		},
+	}
+
+	if err := repo.UpsertFlag(context.Background(), flagDef); err != nil {
+		t.Fatalf("UpsertFlag: %v", err)
+	}
+
+	router, err := httpserver.NewRouter(httpserver.Config{FlagService: service})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	provider := newHTTPProvider(server.URL)
+	if err := openfeature.SetProviderAndWait(provider); err != nil {
+		t.Fatalf("SetProviderAndWait: %v", err)
+	}
+	t.Cleanup(openfeature.Shutdown)
+
+	client := openfeature.NewClient("checkout-http")
+	targetedCtx := openfeature.NewTargetlessEvaluationContext(map[string]any{"country": "DE"})
+
+	details, err := client.BooleanValueDetails(context.Background(), "checkout-flow", false, targetedCtx)
+	if err != nil {
+		t.Fatalf("BooleanValueDetails: %v", err)
+	}
+	if details.Value != true {
+		t.Fatalf("expected true variation for targeted context, got %v", details.Value)
+	}
+	if details.Reason != openfeature.TargetingMatchReason {
+		t.Fatalf("expected reason %s, got %s", openfeature.TargetingMatchReason, details.Reason)
+	}
+	if details.Variant != "enabled" {
+		t.Fatalf("expected variant 'enabled', got %s", details.Variant)
+	}
+
+	defaultCtx := openfeature.NewTargetlessEvaluationContext(map[string]any{"country": "US"})
+	defaultDetails, err := client.BooleanValueDetails(context.Background(), "checkout-flow", false, defaultCtx)
+	if err != nil {
+		t.Fatalf("BooleanValueDetails default: %v", err)
+	}
+	if defaultDetails.Value != false {
+		t.Fatalf("expected default false variation, got %v", defaultDetails.Value)
+	}
+	if defaultDetails.Reason != openfeature.DefaultReason {
+		t.Fatalf("expected reason %s, got %s", openfeature.DefaultReason, defaultDetails.Reason)
+	}
+	if defaultDetails.Variant != "control" {
+		t.Fatalf("expected variant 'control', got %s", defaultDetails.Variant)
+	}
+}

--- a/internal/flag/openfeature_integration_test.go
+++ b/internal/flag/openfeature_integration_test.go
@@ -1,0 +1,244 @@
+package flag
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+type serviceProvider struct {
+	service  *Service
+	metadata openfeature.Metadata
+}
+
+func newServiceProvider(svc *Service) *serviceProvider {
+	return &serviceProvider{
+		service:  svc,
+		metadata: openfeature.Metadata{Name: "funwithflags-service"},
+	}
+}
+
+func (p *serviceProvider) Metadata() openfeature.Metadata {
+	return p.metadata
+}
+
+func (p *serviceProvider) Hooks() []openfeature.Hook {
+	return nil
+}
+
+func (p *serviceProvider) BooleanEvaluation(ctx context.Context, flagKey string, defaultValue bool, flatCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+	result, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.BoolResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := result.Variation.Value.(bool)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not boolean")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.BoolResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.BoolResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *serviceProvider) StringEvaluation(ctx context.Context, flagKey string, defaultValue string, flatCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+	result, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.StringResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := result.Variation.Value.(string)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not string")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.StringResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.StringResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *serviceProvider) FloatEvaluation(ctx context.Context, flagKey string, defaultValue float64, flatCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+	result, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.FloatResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := toFloat64(result.Variation.Value)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not float")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.FloatResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.FloatResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *serviceProvider) IntEvaluation(ctx context.Context, flagKey string, defaultValue int64, flatCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+	result, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.IntResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	value, ok := toInt64(result.Variation.Value)
+	if !ok {
+		detail.ResolutionError = openfeature.NewTypeMismatchResolutionError("variation value is not int")
+		detail.Reason = openfeature.ErrorReason
+		return openfeature.IntResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.IntResolutionDetail{Value: value, ProviderResolutionDetail: detail}
+}
+
+func (p *serviceProvider) ObjectEvaluation(ctx context.Context, flagKey string, defaultValue any, flatCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	result, detail, err := p.evaluate(ctx, flagKey, flatCtx)
+	if err != nil {
+		return openfeature.InterfaceResolutionDetail{Value: defaultValue, ProviderResolutionDetail: detail}
+	}
+	return openfeature.InterfaceResolutionDetail{Value: result.Variation.Value, ProviderResolutionDetail: detail}
+}
+
+func (p *serviceProvider) evaluate(ctx context.Context, flagKey string, flatCtx openfeature.FlattenedContext) (EvaluationResult, openfeature.ProviderResolutionDetail, error) {
+	if p.service == nil {
+		return EvaluationResult{}, openfeature.ProviderResolutionDetail{
+			ResolutionError: openfeature.NewGeneralResolutionError("service not configured"),
+			Reason:          openfeature.ErrorReason,
+		}, errors.New("service not configured")
+	}
+
+	attrs := make(EvaluationContext, len(flatCtx))
+	for k, v := range flatCtx {
+		attrs[k] = v
+	}
+
+	res, err := p.service.EvaluateFlag(ctx, flagKey, attrs)
+	if err != nil {
+		detail := openfeature.ProviderResolutionDetail{
+			Reason: openfeature.ErrorReason,
+		}
+		switch {
+		case errors.Is(err, ErrFlagNotFound):
+			detail.ResolutionError = openfeature.NewFlagNotFoundResolutionError(err.Error())
+		case errors.Is(err, ErrInvalidFlag):
+			detail.ResolutionError = openfeature.NewParseErrorResolutionError(err.Error())
+		default:
+			detail.ResolutionError = openfeature.NewGeneralResolutionError(err.Error())
+		}
+		return EvaluationResult{}, detail, err
+	}
+
+	return res, openfeature.ProviderResolutionDetail{
+		Reason:  mapReason(res.Reason),
+		Variant: res.Variation.Key,
+	}, nil
+}
+
+func mapReason(reason string) openfeature.Reason {
+	switch reason {
+	case ReasonTargetMatch:
+		return openfeature.TargetingMatchReason
+	case ReasonPercentageRollout:
+		return openfeature.SplitReason
+	case ReasonDisabled:
+		return openfeature.DisabledReason
+	case ReasonDefault:
+		return openfeature.DefaultReason
+	default:
+		return openfeature.UnknownReason
+	}
+}
+
+func toInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int8:
+		return int64(v), true
+	case int16:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint:
+		return int64(v), true
+	case uint8:
+		return int64(v), true
+	case uint16:
+		return int64(v), true
+	case uint32:
+		return int64(v), true
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func TestOpenFeatureClientIntegration(t *testing.T) {
+	repo := NewInMemoryRepository()
+	engine := NewEngine()
+	service, err := NewService(repo, engine)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	flagDef := FeatureFlag{
+		Key:        "checkout-flow",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []Variation{
+			{Key: "control", Type: BooleanVariation, Value: false},
+			{Key: "enabled", Type: BooleanVariation, Value: true},
+		},
+		Rules: []Rule{
+			{
+				ID:           "country-de",
+				VariationKey: "enabled",
+				Conditions: []Condition{
+					{Attribute: "country", Operator: MatcherEquals, Value: "DE"},
+				},
+			},
+		},
+	}
+
+	if err := repo.UpsertFlag(context.Background(), flagDef); err != nil {
+		t.Fatalf("UpsertFlag: %v", err)
+	}
+
+	provider := newServiceProvider(service)
+	if err := openfeature.SetProviderAndWait(provider); err != nil {
+		t.Fatalf("SetProviderAndWait: %v", err)
+	}
+	t.Cleanup(openfeature.Shutdown)
+
+	client := openfeature.NewClient("checkout")
+	targetedCtx := openfeature.NewTargetlessEvaluationContext(map[string]any{"country": "DE"})
+
+	details, err := client.BooleanValueDetails(context.Background(), "checkout-flow", false, targetedCtx)
+	if err != nil {
+		t.Fatalf("BooleanValueDetails: %v", err)
+	}
+	if details.Value != true {
+		t.Fatalf("expected true variation for targeted context, got %v", details.Value)
+	}
+	if details.Reason != openfeature.TargetingMatchReason {
+		t.Fatalf("expected reason %s, got %s", openfeature.TargetingMatchReason, details.Reason)
+	}
+	if details.Variant != "enabled" {
+		t.Fatalf("expected variant 'enabled', got %s", details.Variant)
+	}
+
+	defaultCtx := openfeature.NewTargetlessEvaluationContext(map[string]any{"country": "US"})
+	defaultDetails, err := client.BooleanValueDetails(context.Background(), "checkout-flow", false, defaultCtx)
+	if err != nil {
+		t.Fatalf("BooleanValueDetails default: %v", err)
+	}
+	if defaultDetails.Value != false {
+		t.Fatalf("expected default false variation, got %v", defaultDetails.Value)
+	}
+	if defaultDetails.Reason != openfeature.DefaultReason {
+		t.Fatalf("expected reason %s, got %s", openfeature.DefaultReason, defaultDetails.Reason)
+	}
+	if defaultDetails.Variant != "control" {
+		t.Fatalf("expected variant 'control', got %s", defaultDetails.Variant)
+	}
+}

--- a/internal/flag/service.go
+++ b/internal/flag/service.go
@@ -1,0 +1,35 @@
+package flag
+
+import (
+	"context"
+	"fmt"
+)
+
+type Service struct {
+	repo      Repository
+	evaluator Evaluator
+}
+
+func NewService(repo Repository, evaluator Evaluator) (*Service, error) {
+	if repo == nil {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if evaluator == nil {
+		return nil, fmt.Errorf("evaluator is required")
+	}
+	return &Service{repo: repo, evaluator: evaluator}, nil
+}
+
+func (s *Service) EvaluateFlag(ctx context.Context, key string, attrs EvaluationContext) (EvaluationResult, error) {
+	if key == "" {
+		return EvaluationResult{}, fmt.Errorf("flag key is required")
+	}
+	flag, err := s.repo.GetFlag(ctx, key)
+	if err != nil {
+		return EvaluationResult{}, err
+	}
+	if attrs == nil {
+		attrs = EvaluationContext{}
+	}
+	return s.evaluator.Evaluate(ctx, flag, attrs)
+}

--- a/internal/httpserver/evaluate.go
+++ b/internal/httpserver/evaluate.go
@@ -14,11 +14,11 @@ type evaluateRequest struct {
 }
 
 type evaluateResponse struct {
-	FlagKey       string      `json:"flagKey"`
-	VariationKey  string      `json:"variationKey"`
-	VariationType string      `json:"variationType"`
-	Value         any         `json:"value"`
-	Reason        string      `json:"reason"`
+	FlagKey       string `json:"flagKey"`
+	VariationKey  string `json:"variationKey"`
+	VariationType string `json:"variationType"`
+	Value         any    `json:"value"`
+	Reason        string `json:"reason"`
 }
 
 func newEvaluateHandler(service *flag.Service) http.HandlerFunc {

--- a/internal/httpserver/evaluate.go
+++ b/internal/httpserver/evaluate.go
@@ -1,0 +1,70 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/deicon/funwithflags/internal/flag"
+)
+
+type evaluateRequest struct {
+	Context map[string]any `json:"context"`
+}
+
+type evaluateResponse struct {
+	FlagKey       string      `json:"flagKey"`
+	VariationKey  string      `json:"variationKey"`
+	VariationType string      `json:"variationType"`
+	Value         any         `json:"value"`
+	Reason        string      `json:"reason"`
+}
+
+func newEvaluateHandler(service *flag.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if service == nil {
+			writeError(w, http.StatusInternalServerError, "evaluation service not configured")
+			return
+		}
+
+		flagKey := r.PathValue("key")
+		if flagKey == "" {
+			writeError(w, http.StatusBadRequest, "flag key missing from path")
+			return
+		}
+
+		var req evaluateRequest
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				req.Context = map[string]any{}
+			} else {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+		}
+
+		ctx := flag.EvaluationContext(req.Context)
+		result, err := service.EvaluateFlag(r.Context(), flagKey, ctx)
+		if err != nil {
+			switch {
+			case errors.Is(err, flag.ErrFlagNotFound):
+				writeError(w, http.StatusNotFound, "flag not found")
+			default:
+				writeError(w, http.StatusInternalServerError, "evaluation failed")
+			}
+			return
+		}
+
+		resp := evaluateResponse{
+			FlagKey:       flagKey,
+			VariationKey:  result.Variation.Key,
+			VariationType: string(result.Variation.Type),
+			Value:         result.Variation.Value,
+			Reason:        result.Reason,
+		}
+
+		writeJSON(w, http.StatusOK, resp)
+	}
+}

--- a/internal/httpserver/evaluate_test.go
+++ b/internal/httpserver/evaluate_test.go
@@ -1,0 +1,120 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deicon/funwithflags/internal/flag"
+)
+
+func TestEvaluateFlag_Success(t *testing.T) {
+	repo := flag.NewInMemoryRepository()
+	engine := flag.NewEngine()
+	service, err := flag.NewService(repo, engine)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	flagDef := flag.FeatureFlag{
+		Key:        "checkout",
+		Enabled:    true,
+		DefaultKey: "control",
+		Variations: []flag.Variation{
+			{Key: "control", Type: flag.BooleanVariation, Value: false},
+			{Key: "variant", Type: flag.BooleanVariation, Value: true},
+		},
+		Rules: []flag.Rule{
+			{
+				ID:           "country-de",
+				VariationKey: "variant",
+				Conditions: []flag.Condition{
+					{Attribute: "country", Operator: flag.MatcherEquals, Value: "DE"},
+				},
+			},
+		},
+	}
+	if err := repo.UpsertFlag(context.Background(), flagDef); err != nil {
+		t.Fatalf("UpsertFlag: %v", err)
+	}
+
+	router, err := NewRouter(Config{FlagService: service})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+
+	payload := `{"context":{"country":"DE"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/flags/checkout/evaluate", bytes.NewBufferString(payload))
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp evaluateResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.VariationKey != "variant" {
+		t.Fatalf("expected variation 'variant', got %s", resp.VariationKey)
+	}
+	if resp.Reason != flag.ReasonTargetMatch {
+		t.Fatalf("expected reason %s, got %s", flag.ReasonTargetMatch, resp.Reason)
+	}
+}
+
+func TestEvaluateFlag_NotFound(t *testing.T) {
+	engine := flag.NewEngine()
+	repo := flag.NewInMemoryRepository()
+	service, err := flag.NewService(repo, engine)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	router, err := NewRouter(Config{FlagService: service})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/flags/missing/evaluate", bytes.NewBufferString(`{}`))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestEvaluateFlag_InvalidJSON(t *testing.T) {
+	engine := flag.NewEngine()
+	repo := flag.NewInMemoryRepository()
+	service, err := flag.NewService(repo, engine)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	router, err := NewRouter(Config{FlagService: service})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/flags/test/evaluate", bytes.NewBufferString(`{"context":`))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestNewRouterRequiresService(t *testing.T) {
+	if _, err := NewRouter(Config{}); err == nil {
+		t.Fatalf("expected error when service missing")
+	}
+}

--- a/internal/httpserver/health.go
+++ b/internal/httpserver/health.go
@@ -1,25 +1,15 @@
 package httpserver
 
-import (
-	"encoding/json"
-	"net/http"
-)
+import "net/http"
 
 type healthResponse struct {
 	Status string `json:"status"`
 }
 
 func livenessHandler(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, healthResponse{Status: "ok"})
+	writeJSON(w, http.StatusOK, healthResponse{Status: "ok"})
 }
 
 func readinessHandler(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, healthResponse{Status: "ready"})
-}
-
-func writeJSON(w http.ResponseWriter, payload any) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(payload); err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
-	}
+	writeJSON(w, http.StatusOK, healthResponse{Status: "ready"})
 }

--- a/internal/httpserver/response.go
+++ b/internal/httpserver/response.go
@@ -1,0 +1,22 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -1,10 +1,25 @@
 package httpserver
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
 
-func NewRouter() http.Handler {
+	"github.com/deicon/funwithflags/internal/flag"
+)
+
+type Config struct {
+	FlagService *flag.Service
+}
+
+func NewRouter(cfg Config) (*http.ServeMux, error) {
+	if cfg.FlagService == nil {
+		return nil, fmt.Errorf("flag service is required")
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", http.HandlerFunc(livenessHandler))
 	mux.Handle("/readyz", http.HandlerFunc(readinessHandler))
-	return mux
+	mux.HandleFunc("POST /api/v1/flags/{key}/evaluate", newEvaluateHandler(cfg.FlagService))
+
+	return mux, nil
 }


### PR DESCRIPTION
## Description
This PR introduces the core functionality for evaluating feature flags within the `FunWithFlags` service. It lays the foundation for future features such as persistence and a management UI.

## Motivation
The primary goal is to provide a functional feature flag evaluation service that adheres to the OpenFeature specification. This allows OpenFeature clients to utilize the service for dynamic feature toggling.

## What was changed
- **README.md:** Updated with instructions on running the server and evaluating flags. Added project status, prerequisites, and development workflow sections.
- **go.mod:** Upgraded Go version to 1.24 and added `open-feature/go-sdk` as a dependency.
- **internal/app/app.go:** Modified to initialize the flag service and inject it into the HTTP router.
- **internal/flag/:** Added new files `errors.go`, `evaluator.go`, `evaluator_test.go`, `memory_repository.go`, `memory_repository_test.go`, `model.go`, `service.go`, `openfeature_integration_test.go`, `openfeature_http_integration_test.go` which implements:
    - Defines data structures and interfaces for feature flags, variations, rules, and evaluation contexts (`model.go`).
    - Implements an in-memory repository for storing feature flags (`memory_repository.go`).
    - Creates an evaluation engine that determines the appropriate variation based on rules and context (`evaluator.go`).
    - Defines a service layer to handle flag evaluations (`service.go`).
    - Includes unit and integration tests for the in-memory repository and evaluation engine (`memory_repository_test.go`, `evaluator_test.go`, `openfeature_integration_test.go`, `openfeature_http_integration_test.go`).
- **internal/httpserver/:** Added new files `evaluate.go`, `evaluate_test.go`, `response.go` and modified `router.go` to:
    - Implements the `POST /api/v1/flags/{key}/evaluate` endpoint to evaluate flags via HTTP (`evaluate.go`).
    - Handles request parsing, flag evaluation, and response formatting.
    - Implements helper functions for writing JSON responses and errors (`response.go`).
    - Integrates the evaluation handler into the HTTP router (`router.go`).

## Tests
- Extensive unit and integration tests have been added to cover the evaluation engine, in-memory repository, and HTTP endpoint.
- Includes an end-to-end test using the OpenFeature Go SDK to interact with the HTTP endpoint.
